### PR TITLE
Switch dashboard and profile views to layout inheritance

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,10 +1,10 @@
-<x-app-layout>
-    <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Dashboard') }}
-        </h2>
-    </x-slot>
+@php($header = new \Illuminate\Support\HtmlString(
+    '<h2 class="font-semibold text-xl text-gray-800 leading-tight">'.__('Dashboard').'</h2>'
+))
 
+@extends('layouts.app')
+
+@section('content')
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
@@ -14,4 +14,4 @@
             </div>
         </div>
     </div>
-</x-app-layout>
+@endsection

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -1,10 +1,10 @@
-<x-app-layout>
-    <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Profile') }}
-        </h2>
-    </x-slot>
+@php($header = new \Illuminate\Support\HtmlString(
+    '<h2 class="font-semibold text-xl text-gray-800 leading-tight">'.__('Profile').'</h2>'
+))
 
+@extends('layouts.app')
+
+@section('content')
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
             <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
@@ -26,4 +26,4 @@
             </div>
         </div>
     </div>
-</x-app-layout>
+@endsection


### PR DESCRIPTION
## Summary
- convert dashboard and profile views to use `@extends('layouts.app')`
- move header slot contents into `$header` variables

## Testing
- `composer install`
- `npm run build`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68816dc3be5c832e8359f65904bb4c6d